### PR TITLE
I think this is the data loss bug

### DIFF
--- a/playpen.cc
+++ b/playpen.cc
@@ -308,9 +308,6 @@ int main(int argc, char **argv) {
         err(1, "clone");
     }
 
-    close(pipe_out[1]);
-    close(pipe_err[1]);
-
     struct epoll_event events[4];
     struct itimerspec spec = {
         .it_value.tv_sec = timeout


### PR DESCRIPTION
If the cloned process exits too quickly the pipes are destroyed and the program with suffer data loss or other strange behaviours.
